### PR TITLE
Fix #3 - indentNextLinePattern is unused

### DIFF
--- a/Preferences/Indentation Rules.tmPreferences
+++ b/Preferences/Indentation Rules.tmPreferences
@@ -12,8 +12,6 @@
 		<string>^(.*\*/)?\s*\}[;\s]*$</string>
 		<key>increaseIndentPattern</key>
 		<string>^.*(\{[^}"']*|["']\w+["']:)$</string>
-		<key>indentNextLinePattern</key>
-		<string></string>
 		<key>unIndentedLinePattern</key>
 		<string>^\s*((/\*|\*/|#).*)?$</string>
 	</dict>


### PR DESCRIPTION
Let's get rid of it. We might revisit this if we want to be able to align
parameters of functions when split over several lines (which is quite
unfrequent in Puppet manifests).

Signed-off-by: brice brice@daysofwonder.com
